### PR TITLE
TSChecker

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -20,6 +20,7 @@ class CfgFunctions
 			class showLocalMissionError {};
 			class showLocalMissionNotification {};
 			class createAceActionLocal {};
+			class teamSpeakChecker {};
 		};
 		class engine
 		{

--- a/functions/client/fn_teamSpeakChecker.sqf
+++ b/functions/client/fn_teamSpeakChecker.sqf
@@ -1,0 +1,17 @@
+if(call TFAR_fnc_isTeamSpeakPluginEnabled) exitWith {};
+_bw = ppEffectCreate ["colorCorrections", 1501];
+_bw ppEffectAdjust [1, 1, 0, [1, 1, 1, 0], [1, 1, 1, 0], [0.75, 0.25, 0, 1.0]];
+_bw ppEffectCommit 1;
+_bw ppEffectEnable TRUE;
+
+sleep 2;
+
+titleText ["<t size=2>Merci de rejoindre notre serveur TeamSpeak</t>", "PLAIN", 3, true, true];
+
+while{!call TFAR_fnc_isTeamSpeakPluginEnabled} do {
+	sleep 1;
+	titleText ["<t size=2>Merci de rejoindre notre serveur TeamSpeak</t>", "PLAIN", 0, true, true];
+};
+
+titleText["", "PLAIN"];
+ppEffectDestroy _bw;

--- a/initPlayerLocal.sqf
+++ b/initPlayerLocal.sqf
@@ -1,5 +1,8 @@
 //exec: client
 
+//vérification TeamSpeak
+call LM_fnc_teamSpeakChecker;
+
 /////////////////////////////////////   Interactions commandant   /////////////////////////////////////
 _statement = {
 	remoteExec ["LM_fnc_lancerMissionMain", 2];


### PR DESCRIPTION
Ajoute une fonction vérifiant si le joueur est bien connecté à TeamSpeak et a son plugin activé au démarrage de la mission. Si ce n'est pas le cas, le jeu s'affichera en nuances de gris et un message clignotera au milieu de l'écran. Le retour à la normale se fait dès que le joueur est correctement connecté à TeamSpeak. Une fois l'initialisation passée, les joueurs peuvent désactiver leur plugin pour des besoins de débrief/tests/etc sans que l'écran ne redevienne gris.