### PR TITLE
Side/archeo

### DIFF
--- a/fob/roadtrip/side/side3.sqf
+++ b/fob/roadtrip/side/side3.sqf
@@ -21,7 +21,7 @@ _site1 = [
 ];
 
 _site2 = [
-	["Land_AncientPillar_F",[27971.2,24109.3,-9.40232],0],
+	["Land_AncientPillar_F",[27971.2,24109.3,-8.6],0],
 	["Land_Stone_pillar_F",[27966.4,24108.3,-1.7829],0],
 	["Land_AncientPillar_fallen_F",[27974.5,24113.5,-1.09067],190],
 	["Land_AncientPillar_fallen_F",[27972.1,24105.1,-0.987808],0]
@@ -46,7 +46,7 @@ _obli = selectRandom _sites;
 _sites = _sites - _obli;
 
 // Site secondaire
-if(random 1 < 0.6) then {
+if(random 1 < 0.5) then {
 	_second = selectRandom _sites;
 	_sites = _sites - _second;
 };
@@ -79,12 +79,14 @@ LM_COMMANDER setVariable ["roadtrip_side3", 0, false]; // Variable du commandant
 
 		// Ajout du trigger de découverte
 		_pos = ((_x select 0) select 1); //position du premier objet de chaque site
+		_pos = [(_pos select 0), (_pos select 1), 0]; //Réinitialisation au niveau du sol pour éviter le trigger souterrain
 		_trigger = createTrigger ["EmptyDetector", _pos, false];
 		_trigger setPosATL _pos;
 		_trigger setTriggerArea [5, 5, 0, false, 5]; //sphère de 5m de rayon
 		_trigger setTriggerActivation ["WEST", "PRESENT", false];
 		_trigger setTriggerStatements ["this", "
 			LM_COMMANDER setVariable ['roadtrip_side3', (LM_COMMANDER getVariable 'roadtrip_side3')+1];
+			['Exercice de plongée : nouveau site antique découvert !'] remoteExec ['systemChat', 0];
 			deleteVehicle thisTrigger;
 		", ""];
 	};

--- a/fob/roadtrip/side/side3.sqf
+++ b/fob/roadtrip/side/side3.sqf
@@ -2,27 +2,37 @@
 // Author : [LM]Cheitan
 // Team   : La Muerta
 
+_marker_roadtrip_side3 = createMarker ["marker_roadtrip_side3", [27881.8,24036.3]];
+"marker_roadtrip_side3" setMarkerShape "ellipse";
+"marker_roadtrip_side3" setMarkerSize [150,150];
+"marker_roadtrip_side3" setMarkerBrush "Horizontal";
+"marker_roadtrip_side3" setMarkerAlpha 0.5;
+"marker_roadtrip_side3" setMarkerColor "ColorOrange";
+
+[WEST,["task_roadtrip_side3","task_fob_roadtrip"],["Des plongeurs amateurs ont aidé à faire un relevé de l'état des côtes. Un groupe au nord-est de l'île a signalé un <marker name='marker_roadtrip_side3'>banc de sable en cours d'érosion</marker> à cause d'un courant marin saisonnier. Dans le creux formé, ils ont aperçu des objets qu'ils identifient comme des ruines antiques. Si cela se révèle exact, le gouvernement de la République d'Altis et Stratis serait en droit de demander de nouvelles aides aux Nations-Unies, afin de protéger ce site archéologique. Le gouvernement a demandé à notre commandement d'effectuer un relevé un peu plus précis. Cela n'entre normalement pas dans nos attributions, mais le commandement a discrètement laissé entendre que si jamais des ruines antiques étaient découvertes au détour d'un entrainement de plongée, alors les lois en vigueur l'obligerait à prendre des mesures allant dans le sens du gouvernement. Ca tombe bien, on vient juste d'apprendre que les exercices de plongée se dérouleront désormais dans un secteur tout proche du lieu concerné. Le hasard fait bien les choses, pas vrai ?", "Exercice de plongée","marker_roadtrip_side3"],getMarkerPos "marker_roadtrip_side3",true,1,true,"boat"] call BIS_fnc_taskCreate;
+
+
 _site1 = [
+	["Land_Statue_01_F",[27926.4,24120.6,-2.0587],270],
 	["Land_Mound02_8m_F",[27927.3,24116.7,-0.0660877],0],
 	["Land_Mound02_8m_F",[27923.6,24121.6,-0.170534],90],
-	["Land_Statue_01_F",[27926.4,24120.6,-2.0587],270],
 	["Land_Fortress_01_bricks_v2_F",[27935.4,24117.3,-0.276903],0],
 	["Land_Fortress_01_bricks_v1_F",[27938.6,24120.3,-0.615023],0]
 ];
 
 _site2 = [
+	["Land_AncientPillar_F",[27971.2,24109.3,-9.40232],0],
 	["Land_Stone_pillar_F",[27966.4,24108.3,-1.7829],0],
-	["Land_AncientPillar_fallen_F",[27974.5,24113.5,-1.09067],190.337],
-	["Land_AncientPillar_fallen_F",[27972.1,24105.1,-0.987808],0],
-	["Land_AncientPillar_F",[27971.2,24109.3,-9.40232],0]
+	["Land_AncientPillar_fallen_F",[27974.5,24113.5,-1.09067],190],
+	["Land_AncientPillar_fallen_F",[27972.1,24105.1,-0.987808],0]
 ];
 
 _site3 = [
+	["Land_AncientPillar_fallen_F",[27985.3,24139.3,-1.08024],0],
 	["Land_GardenPavement_02_F",[27988.5,24136.4,-0.0787945],0],
 	["Land_GardenPavement_02_F",[27988.2,24131.3,-0.0309391],0],
 	["Land_GardenPavement_02_F",[27988.1,24127.7,0.051796],0],
 	["Land_Ancient_Wall_8m_F",[27981.9,24131.2,-0.870344],270],
-	["Land_AncientPillar_fallen_F",[27985.3,24139.3,-1.08024],0],
 	["Land_AncientPillar_damaged_F",[27990.1,24139.2,-4.70786],0]
 ];
 
@@ -47,46 +57,40 @@ if(random 1 < 0.2) then {
 	_sites = _sites - _impro;
 };
 
+// Compteur de découvertes
+_total = 0;
+LM_COMMANDER setVariable ["roadtrip_side3", 0, false]; // Variable du commandant afin que les triggers y ait accès
+
 {
-	// Vérif si pas vide, et création
+	if(count _x > 0) then {
+		_liste = _x;
+
+		// Spawn des objets de ce site
+		{
+			_obj = createVehicle [(_x select 0), (_x select 1), [], 0, "CAN_COLLIDE"];
+			_obj enableSimulation false;
+			_obj setPosATL (_x select 1);
+			_obj setDir (_x select 2);
+			(LM_MISSION_FOB_TEMP select 2) pushBack _obj;
+		} forEach _liste;
+
+		// Ajout d'un site au nombre total de sites à découvrir
+		_total = _total + 1;
+
+		// Ajout du trigger de découverte
+		_pos = ((_x select 0) select 1); //position du premier objet de chaque site
+		_trigger = createTrigger ["EmptyDetector", _pos, false];
+		_trigger setPosATL _pos;
+		_trigger setTriggerArea [5, 5, 0, false, 5]; //sphère de 5m de rayon
+		_trigger setTriggerActivation ["WEST", "PRESENT", false];
+		_trigger setTriggerStatements ["this", "
+			LM_COMMANDER setVariable ['roadtrip_side3', (LM_COMMANDER getVariable 'roadtrip_side3')+1];
+			deleteVehicle thisTrigger;
+		", ""];
+	};
 } forEach [_obli, _second, _impro];
 
-
-
-
-
-_marker_roadtrip_side2 = createMarker ["marker_roadtrip_side2", [26293.1,25941.1]];
-"marker_roadtrip_side2" setMarkerShape "ellipse";
-"marker_roadtrip_side2" setMarkerSize [2500,700];
-"marker_roadtrip_side2" setMarkerDir 200;
-"marker_roadtrip_side2" setMarkerBrush "Horizontal";
-"marker_roadtrip_side2" setMarkerAlpha 0.5;
-"marker_roadtrip_side2" setMarkerColor "ColorOrange";
-
-_centre = [27940.6,25293.7,0];
-
-{
-	//Créer l'objet
-	_vehicle = createVehicle [_x, [0,0,0], [], 0, "NONE"];
-	//Position aléatoire
-	_vehicle setPosATL (_centre getPos [floor(random 400), floor(random 360)]);
-	//Création de marker dessus
-	_marker = createMarker [format["mark_%1", _x], getPos _vehicle];
-	_marker setMarkerType "mil_triangle";
-	_marker setMarkerColor "ColorRed";
-	//Action ACE de ramassage
-	_statement = {
-		params ["_target", "_player", "_params"];
-		deleteMarker format["mark_%1", typeOf _target];
-		if(typeOf _target isEqualTo "Land_FoodContainer_01_F") then {['task_roadtrip_side2', 'SUCCEEDED'] call BIS_fnc_taskSetState};
-		deleteVehicle _target;
-	};
-	[_vehicle,0,["ACE_MainActions"],format["take_%",_forEachIndex],"Ramasser","",_statement,{true}] call LM_fnc_createAceActionGlobal;
-	//Ajout à la suppression, au cas où
-	(LM_MISSION_FOB_TEMP select 2) pushBack _vehicle;
-} forEach _objets;
-
-[WEST,["task_roadtrip_side2","task_fob_roadtrip"],["Suite à une erreur humaine, un satellite de notre flotte d'observation a raclé l'atmosphère d'un peu trop près. Bien évidemment, la majeure partie de l'engin s'est désintégré durant la chute, mais certaines pièces légères ou spécialement conçues ont pu parvenir jusqu'au sol. En particulier, l'ordinateur central de l'appareil devrait avoir survécu à la descente, protégé par un caisson spécial. Il nous serait utile de retrouver ce caisson afin de comprendre pourquoi la manoeuvre effectuée a désorbité l'appareil. Nous avons suivi durant la chute quelques gros débris. La majeure partie d'entre eux s'est écrasée en mer, mais certains ont touché l'île, et sont marqués sur votre carte. Avec un peu de chance, le caisson sera l'un d'entre eux. Trouvez-le, et ramassez aussi les autres débris si vous en avez le temps.", "Désorbitage imprévu","marker_roadtrip_side2"],_centre,true,1,true,"search"] call BIS_fnc_taskCreate;
-
-waitUntil { sleep 2; ("task_roadtrip_side2" call BIS_fnc_taskState) isEqualTo "SUCCEEDED" };
-deleteMarker _marker_roadtrip_side2;
+waitUntil { sleep 2; (LM_COMMANDER getVariable "roadtrip_side3") == _total };
+deleteMarker _marker_roadtrip_side3;
+["task_roadtrip_side3", "SUCCEEDED"] call BIS_fnc_taskSetState;
+LM_COMMANDER setVariable ["roadtrip_side3", nil];

--- a/fob/roadtrip/side/side3.sqf
+++ b/fob/roadtrip/side/side3.sqf
@@ -1,0 +1,92 @@
+﻿// ------ Side archéologie -----
+// Author : [LM]Cheitan
+// Team   : La Muerta
+
+_site1 = [
+	["Land_Mound02_8m_F",[27927.3,24116.7,-0.0660877],0],
+	["Land_Mound02_8m_F",[27923.6,24121.6,-0.170534],90],
+	["Land_Statue_01_F",[27926.4,24120.6,-2.0587],270],
+	["Land_Fortress_01_bricks_v2_F",[27935.4,24117.3,-0.276903],0],
+	["Land_Fortress_01_bricks_v1_F",[27938.6,24120.3,-0.615023],0]
+];
+
+_site2 = [
+	["Land_Stone_pillar_F",[27966.4,24108.3,-1.7829],0],
+	["Land_AncientPillar_fallen_F",[27974.5,24113.5,-1.09067],190.337],
+	["Land_AncientPillar_fallen_F",[27972.1,24105.1,-0.987808],0],
+	["Land_AncientPillar_F",[27971.2,24109.3,-9.40232],0]
+];
+
+_site3 = [
+	["Land_GardenPavement_02_F",[27988.5,24136.4,-0.0787945],0],
+	["Land_GardenPavement_02_F",[27988.2,24131.3,-0.0309391],0],
+	["Land_GardenPavement_02_F",[27988.1,24127.7,0.051796],0],
+	["Land_Ancient_Wall_8m_F",[27981.9,24131.2,-0.870344],270],
+	["Land_AncientPillar_fallen_F",[27985.3,24139.3,-1.08024],0],
+	["Land_AncientPillar_damaged_F",[27990.1,24139.2,-4.70786],0]
+];
+
+_sites = [_site1, _site2, _site3];
+_obli = [];
+_second = [];
+_impro = [];
+
+// Site obligatoire
+_obli = selectRandom _sites;
+_sites = _sites - _obli;
+
+// Site secondaire
+if(random 1 < 0.6) then {
+	_second = selectRandom _sites;
+	_sites = _sites - _second;
+};
+
+// Site improbable
+if(random 1 < 0.2) then {
+	_impro = selectRandom _sites;
+	_sites = _sites - _impro;
+};
+
+{
+	// Vérif si pas vide, et création
+} forEach [_obli, _second, _impro];
+
+
+
+
+
+_marker_roadtrip_side2 = createMarker ["marker_roadtrip_side2", [26293.1,25941.1]];
+"marker_roadtrip_side2" setMarkerShape "ellipse";
+"marker_roadtrip_side2" setMarkerSize [2500,700];
+"marker_roadtrip_side2" setMarkerDir 200;
+"marker_roadtrip_side2" setMarkerBrush "Horizontal";
+"marker_roadtrip_side2" setMarkerAlpha 0.5;
+"marker_roadtrip_side2" setMarkerColor "ColorOrange";
+
+_centre = [27940.6,25293.7,0];
+
+{
+	//Créer l'objet
+	_vehicle = createVehicle [_x, [0,0,0], [], 0, "NONE"];
+	//Position aléatoire
+	_vehicle setPosATL (_centre getPos [floor(random 400), floor(random 360)]);
+	//Création de marker dessus
+	_marker = createMarker [format["mark_%1", _x], getPos _vehicle];
+	_marker setMarkerType "mil_triangle";
+	_marker setMarkerColor "ColorRed";
+	//Action ACE de ramassage
+	_statement = {
+		params ["_target", "_player", "_params"];
+		deleteMarker format["mark_%1", typeOf _target];
+		if(typeOf _target isEqualTo "Land_FoodContainer_01_F") then {['task_roadtrip_side2', 'SUCCEEDED'] call BIS_fnc_taskSetState};
+		deleteVehicle _target;
+	};
+	[_vehicle,0,["ACE_MainActions"],format["take_%",_forEachIndex],"Ramasser","",_statement,{true}] call LM_fnc_createAceActionGlobal;
+	//Ajout à la suppression, au cas où
+	(LM_MISSION_FOB_TEMP select 2) pushBack _vehicle;
+} forEach _objets;
+
+[WEST,["task_roadtrip_side2","task_fob_roadtrip"],["Suite à une erreur humaine, un satellite de notre flotte d'observation a raclé l'atmosphère d'un peu trop près. Bien évidemment, la majeure partie de l'engin s'est désintégré durant la chute, mais certaines pièces légères ou spécialement conçues ont pu parvenir jusqu'au sol. En particulier, l'ordinateur central de l'appareil devrait avoir survécu à la descente, protégé par un caisson spécial. Il nous serait utile de retrouver ce caisson afin de comprendre pourquoi la manoeuvre effectuée a désorbité l'appareil. Nous avons suivi durant la chute quelques gros débris. La majeure partie d'entre eux s'est écrasée en mer, mais certains ont touché l'île, et sont marqués sur votre carte. Avec un peu de chance, le caisson sera l'un d'entre eux. Trouvez-le, et ramassez aussi les autres débris si vous en avez le temps.", "Désorbitage imprévu","marker_roadtrip_side2"],_centre,true,1,true,"search"] call BIS_fnc_taskCreate;
+
+waitUntil { sleep 2; ("task_roadtrip_side2" call BIS_fnc_taskState) isEqualTo "SUCCEEDED" };
+deleteMarker _marker_roadtrip_side2;

--- a/functions/engine/fn_getRandomMissionNumber.sqf
+++ b/functions/engine/fn_getRandomMissionNumber.sqf
@@ -56,7 +56,7 @@ if(_type == "main") then {
 		case "base": { 1 };
 		case "greenvalley": { 1 };
 		case "highwatch": { 1 };
-		case "roadtrip": { 2 };
+		case "roadtrip": { 3 };
 		case "southblues": { 1 };
 	};
 };


### PR DESCRIPTION
Nouvelle mission secondaire pour Roadtrip.

L'objectif est de trouver le(s) site(s) antique(s) repéré(s) par des plongeurs civils dans un banc de sable en cours d'érosion, proche de la côte nord-est de l'île.

Le nombre de site à trouver va de 1 minimum à 3 maximum. Ce nombre n'est pas connu au moment de la mission. Lorsqu'un nouveau site est découvert, un message s'affiche en bas à gauche de l'écran confirmant la découverte. Lorsque tous les sites ont été trouvés, la mission prend fin automatiquement et la notification de mission réussie est affichée.